### PR TITLE
Fix clobbered request URL

### DIFF
--- a/src/Omniphx/Forrest/Client.php
+++ b/src/Omniphx/Forrest/Client.php
@@ -184,6 +184,7 @@ abstract class Client
         } catch (TokenExpiredException $e) {
             $this->refresh();
 
+            $this->url = $url;
             return $this->handleRequest();
         }
     }


### PR DESCRIPTION
Hello! Thank you for Forrest, it makes interacting with Salesforce somewhat painless which makes us happy :clap:

We are facing an issue where Forrest doesn't properly recover from a `TokenExpiredException`. We are using the `UserPasswordSoap` authentication method (& haven't tried to reproduce this with any of the other methods). Here's a rough overview of what happens:

- Make a request, such as with `Forrest::custom()`
- Response indicates the token is expired and Forrest throws `TokenExpiredException`
- Forrest `Client.php` calls `$this->refresh()` to try to get a new token (which it does successfully)
- Once the refresh is done, Forrest tries to reissue the original request by calling `$this->handleRequest()`
- The response that finally comes back is for the wrong request

The requests that Forrest makes during this process look like:

- Original request: https://cs127.salesforce.com/services/data/v51.0/sobjects/Contact/describe - returns a 401
- Forrest reauthenticates: https://test.salesforce.com/services/Soap/u/46.0
- Forrest bookkeeping: https://cs127.salesforce.com/services/data
- Forrest bookkeeping: https://cs127.salesforce.com/services/data/v52.0
- Reissue original request: https://cs127.salesforce.com/services/data/v52.0

Clearly something has overwritten `$this->url` by the time Forrest is ready to reissue the original request. I haven't found what it is after a quick look, but correcting the URL before calling `handleRequest` makes it work as expected.